### PR TITLE
feat: add gvfs-smb to packages

### DIFF
--- a/build_files/01-theme.sh
+++ b/build_files/01-theme.sh
@@ -38,6 +38,7 @@ dnf -y install \
     gnome-keyring \
     greetd \
     greetd-selinux \
+    gvfs-smb \
     input-remapper \
     just \
     nautilus \


### PR DESCRIPTION
Currently Nautilus isn't able to mount/connect to SMB shares :(