### PR TITLE
add samba support with gvfs-smb

### DIFF
--- a/build_files/00-base.sh
+++ b/build_files/00-base.sh
@@ -31,7 +31,7 @@ dnf -y remove console-login-helper-messages \
     chrony
 
 dnf -y install \
-	cifs_utils \
+	cifs-utils \
     gvfs-smb \
     plymouth \
     plymouth-system-theme \


### PR DESCRIPTION
Adds support for Samba shares to gvfs applications like Nautilus

Sorry, i messed up and the last PR got deleted

Closes https://github.com/zirconium-dev/zirconium/issues/21