### PR TITLE
feat: add nvidia-open support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,6 +25,11 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build/02-extras.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build/03-nvidia.sh
+
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=tmpfs,dst=/var \
+    --mount=type=tmpfs,dst=/tmp \
     /ctx/build/99-cleanup.sh
 
 # This is handy for VM testing

--- a/build_files/02-extras.sh
+++ b/build_files/02-extras.sh
@@ -18,7 +18,3 @@ systemctl preset docker.service docker.socket
 cat >/usr/lib/sysusers.d/docker.conf <<'EOF'
 g docker -
 EOF
-
-if [[ "${BUILD_FLAVOR}" =~ "nvidia" ]] ; then
-  /ctx/build/03-nvidia.sh
-fi

--- a/build_files/03-nvidia.sh
+++ b/build_files/03-nvidia.sh
@@ -1,62 +1,42 @@
 #!/usr/bin/env bash
 
+if [[ ! "${BUILD_FLAVOR}" =~ "nvidia" ]] ; then
+    exit 0
+fi
+
 set -xeuo pipefail
-
-# create /var/tmp dir for akmod build
-mkdir -p /var/tmp
-chmod 1777 /var/tmp
-
-dnf5 config-manager setopt fedora-cisco-openh264.enabled=0
-dnf5 config-manager setopt fedora-multimedia.enabled=1
-
-# Install MULTILIB packages from negativo17-multimedia prior to disabling repo
-dnf5 install -y mesa-dri-drivers.i686 mesa-filesystem.i686 mesa-libEGL.i686 mesa-libGL.i686 mesa-libgbm.i686 mesa-va-drivers.i686 mesa-vulkan-drivers.i686
-dnf5 config-manager setopt fedora-multimedia.enabled=0
 
 KERNEL_VERSION="$(find "/usr/lib/modules" -maxdepth 1 -type d ! -path "/usr/lib/modules" -exec basename '{}' ';' | sort | tail -n 1)"
 
-curl --retry 3 -Lo /etc/yum.repos.d/negativo17-fedora-nvidia.repo https://negativo17.org/repos/fedora-nvidia.repo
-sed -i '/^enabled=1/a\priority=90' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+dnf config-manager addrepo --from-repofile=https://negativo17.org/repos/fedora-nvidia.repo
+dnf config-manager setopt fedora-nvidia.enabled=0
+sed -i '/^enabled=/a\priority=90' /etc/yum.repos.d/fedora-nvidia.repo
 
-dnf5 install -y "akmod-nvidia"
-
-echo "Setting kernel.conf to kernel-open"
-sed -i --sandbox "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel-open/" /etc/nvidia/kernel.conf
-
-echo "Installing kmod..."
+dnf -y install --enablerepo=fedora-nvidia akmod-nvidia
+mkdir -p /var/tmp # for akmods
+chmod 1777 /var/tmp
+sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel-open/" /etc/nvidia/kernel.conf
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
+cat /var/cache/akmods/nvidia/*.failed.log || true
 
-# Depends on word splitting
-# shellcheck disable=SC2086
-modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
-    (cat "/var/cache/akmods/nvidia/*.failed.log" && exit 1)
+dnf -y install --enablerepo=fedora-nvidia \
+    nvidia-driver-cuda libnvidia-fbc libva-nvidia-driver nvidia-driver nvidia-modprobe nvidia-persistenced nvidia-settings
 
-# View license information
-# Depends on word splitting
-# shellcheck disable=SC2086
-modinfo -l /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz
+tee /usr/lib/modprobe.d/00-nouveau-blacklist.conf <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
 
-# nvidia-container-toolkit was disabled for now. according to ublue, it wasn't built with required crypto digests for RPM 6+ introduced in f43
-#curl --retry 3 -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo -o /etc/yum.repos.d/nvidia-container-toolkit.repo
-#sed -i 's/^gpgcheck=0/gpgcheck=1/' /etc/yum.repos.d/nvidia-container-toolkit.repo
-#sed -i 's/^enabled=0.*/enabled=1/' /etc/yum.repos.d/nvidia-container-toolkit.repo
-
-echo "Installing NVIDIA packages..."
-dnf5 -y install nvidia-driver-cuda libnvidia-fbc libva-nvidia-driver nvidia-driver nvidia-modprobe nvidia-persistenced nvidia-settings
-
-curl --retry 3 -L https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp -o nvidia-container.pp
-semodule -i nvidia-container.pp
-
-rm -f nvidia-container.pp
-rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo
-#rm -f /etc/yum.repos.d/nvidia-container-toolkit.repo
+tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<'EOF'
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]
+EOF
 
 # Universal Blue specific Initramfs fixes
-cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+mv /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
 # we must force driver load to fix black screen on boot for nvidia desktops
-sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
-# as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
-sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+sed -i 's/omit_drivers/force_drivers/g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+# as we need forced load, also must pre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
+sed -i 's/ nvidia / i915 amdgpu nvidia /g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
 systemctl disable akmods-keygen@akmods-keygen.service
 systemctl mask akmods-keygen@akmods-keygen.service


### PR DESCRIPTION
This PR adds a support for newer NVIDIA graphic cards starting from GTX 16xx and RTX series (so Turing and up). 

This is a revamp of #6 PR that builds kmod for Fedora kernel (which can be used for any kernel) and adds necessary packages. Hugely based on both secureblue and Universal Blue NVIDIA install scripts.

Installation of nvidia-container-toolkit is removed for now because of "no digest" error.