### PR TITLE
feat(nvidia): add container toolkit

### DIFF
--- a/build_files/03-nvidia.sh
+++ b/build_files/03-nvidia.sh
@@ -64,7 +64,6 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable nvctk-cdi.service
-
 systemctl disable akmods-keygen@akmods-keygen.service
 systemctl mask akmods-keygen@akmods-keygen.service
 systemctl disable akmods-keygen.target


### PR DESCRIPTION
Containers are cool. You know what else is cool? NVIDIA integration. We can now use davincibox or bazzite-arch (for native Steam and Lutris) if you really want to :v:

Note: please use `--nvidia` arg whenever you need to create distrobox container instead of adding `--device nvidia.com/gpu=all` which wouldn't help.