### PR TITLE
Add tailscale-systray user service

### DIFF
--- a/system_files/usr/lib/systemd/user/tailscale-systray.service
+++ b/system_files/usr/lib/systemd/user/tailscale-systray.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tailscale System Tray
+After=systemd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/tailscale systray
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
Since we're installing Tailscale, we might as well also add the systemd user service for the new alpha-status system tray module.

Not everyone uses Tailscale, so I'm not enabling it by default.