### PR TITLE
fix(nvidia): remove kernel.conf and install gcc-c++

### DIFF
--- a/build_files/03-nvidia.sh
+++ b/build_files/03-nvidia.sh
@@ -15,7 +15,7 @@ sed -i '/^enabled=/a\priority=90' /etc/yum.repos.d/fedora-nvidia.repo
 dnf -y install --enablerepo=fedora-nvidia akmod-nvidia
 mkdir -p /var/tmp # for akmods
 chmod 1777 /var/tmp
-sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel-open/" /etc/nvidia/kernel.conf
+dnf -y install gcc-c++
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 cat /var/cache/akmods/nvidia/*.failed.log || true
 


### PR DESCRIPTION
We ALL love when NVIDIA keeps breaking stuff. In order to fix NVIDIA kmod build that is apparently an issue now for other people, all we need is remove kernel.conf and install gcc-c++