### PR TITLE
fix: Remove typo in no-show-user-motd path for zfetch motd

### DIFF
--- a/system_files/usr/share/fish/vendor_conf.d/zfetch.fish
+++ b/system_files/usr/share/fish/vendor_conf.d/zfetch.fish
@@ -3,7 +3,7 @@
 
 function fish_greeting
     if test -d "$HOME"
-        if test ! -e "$HOME"/.config/no-show-user-motd
+        if test ! -e "$HOME"/.config/zirconium/no-show-user-motd
             if test -x /usr/bin/zfetch
                 /usr/bin/zfetch
             end


### PR DESCRIPTION
Noticed this one while setting up my laptop, figured I'd just submit the patch!