### PR TITLE
fix: for layer annotations not being pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       # needed because old podman doesn't push layer annotations for
       # the rpm-ostree rechunker at all
       - name: Install Podman from Brew
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           /home/linuxbrew/.linuxbrew/bin/brew install podman
 


### PR DESCRIPTION
We need a newer podman version than ubuntu 24.04 provides, homebrew is the most elegant solution.

We need the layer annotations for the rpm-ostree rechunker so that updates are more efficient.

workaround for:
https://github.com/containers/podman/issues/27796

WORKS NOW :partying_face: 
skopeo inspect docker://ghcr.io/renner0e/zirconium:latest-arm64
skopeo inspect docker://ghcr.io/renner0e/zirconium:latest-amd64
skopeo inspect docker://ghcr.io/renner0e/zirconium:latest