### PR TITLE
feat: cache rpms for local builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,14 +16,17 @@ ARG BUILD_FLAVOR="${BUILD_FLAVOR:-}"
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/var \
     --mount=type=tmpfs,dst=/tmp \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
     /ctx/build/00-base.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/var \
     --mount=type=tmpfs,dst=/tmp \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
     /ctx/build/01-theme.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
     /ctx/build/02-nvidia.sh
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \

--- a/build_files/00-base.sh
+++ b/build_files/00-base.sh
@@ -7,6 +7,9 @@ systemctl enable systemd-resolved.service
 
 dnf -y install 'dnf5-command(config-manager)'
 
+# Speeds up local builds
+dnf config-manager setopt keepcache=1
+
 dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo
 dnf config-manager setopt tailscale-stable.enabled=0
 dnf -y install --enablerepo='tailscale-stable' tailscale

--- a/build_files/99-cleanup.sh
+++ b/build_files/99-cleanup.sh
@@ -5,6 +5,9 @@ set -xeuo pipefail
 # See https://github.com/CentOS/centos-bootc/issues/191
 mkdir -p /var/roothome
 
+# Revert back to upstream defaults
+dnf config-manager setopt keepcache=0
+
 HOME_URL="https://github.com/zirconium-dev/zirconium"
 echo "zirconium" | tee "/etc/hostname"
 # OS Release File (changed in order with upstream)


### PR DESCRIPTION
This should make local builds about 68±1% faster as the RPMs don't have to be redownloaded again