### PR TITLE
chore: Revert "chore(workflows): remove BTRFS action"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,14 @@ jobs:
         platform: ["amd64", "arm64"]
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
+      - name: Mount BTRFS for podman storage
+        if: ${{ matrix.platform != 'arm64' }}
+        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
This reverts commit 3fa02add50555aec47ee0c153bf2840470c94858.

See: https://github.com/ublue-os/container-storage-action/issues/14