### PR TITLE
feat(ci): use older image as baseline for rechunker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,17 @@ jobs:
       # pull older update so rechunker can use it as baseline
       # this step is skipped whenever we need a fresh rechunk plan
       # (useful for new fedora release every now and then)
+      # TODO: swap to --previous-build when fedora repos gets
+      # rpm-ostree 2026.2 on the next step
       - name: Pull Older Image
         env:
           PLATFORM: ${{ matrix.platform }}
         if: inputs.fresh-rechunk != true
-        run: sudo podman pull ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${PLATFORM}
+        run: |
+          # skip anyway on the first day of every month
+          if [ $(date -u +%d) -ne "01" ]; then
+            sudo podman pull ${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${PLATFORM}
+          fi
 
       # TODO: switch from centos bootc back to reusing local image
       # when fedora repos gets rpm-ostree 2026.1 or newer


### PR DESCRIPTION
This PR pulls an older image to use as baseline for rechunker to do better updates and implements an input for workflow dispatch to clear rechunk history only whenever applicable, similar on how it was done for Legacy Rechunker used in Universal Blue images.

<img width="343" height="289" alt="Screenshot From 2026-02-15 16-17-29" src="https://github.com/user-attachments/assets/e3175edb-e81a-420d-9190-0e6f1e6251a8" />

Ironically CentOS Bootc image is now used to get newer rpm-ostree package because Fedora repos still contains an older version that causes an failure while composing a new commit in edge cases, see a relevant issue attached to the code.