### PR TITLE
Add BASE_OS_NAME field to fastfetch and os-release

### DIFF
--- a/build_files/99-misc-post.sh
+++ b/build_files/99-misc-post.sh
@@ -6,6 +6,9 @@ HOME_URL="https://github.com/zirconium-dev/zirconium"
 echo "zirconium" | tee "/etc/hostname"
 # OS Release File (changed in order with upstream)
 # TODO: change ANSI_COLOR
+bash -c '. /etc/os-release
+echo "BASE_OS_NAME=\"$NAME $VERSION_ID\"" >> /etc/os-release'
+
 sed -i -f - /usr/lib/os-release <<EOF
 s|^NAME=.*|NAME=\"Zirconium\"|
 s|^PRETTY_NAME=.*|PRETTY_NAME=\"Zirconium\"|

--- a/system_files/usr/share/zirconium/fastfetch.jsonc
+++ b/system_files/usr/share/zirconium/fastfetch.jsonc
@@ -23,6 +23,12 @@
             "format": "{pretty-name}"
         },
         {
+            "type": "command",
+            "key": " ",
+            "text": ". /etc/os-release; echo Based on $BASE_OS_NAME",
+            "shell": "/bin/bash"
+        },
+        {
             "type": "kernel",
             "key": " ",
             "format": "{1} {2}"


### PR DESCRIPTION
This adds a new variable to os-release called BASE_OS_NAME. This variable defines the name of the OS of which the current OS is based on. It is a new variable, and is (to my knowledge) not standard anywhere else. It is
however a nice way to show the base OS without bloating PRETTY_NAME or NAME, and being that Zirconium Hawaii exists, it'd be cool to show off the difference in the base OS for the nerds that care.

Resulting `/etc/os-release` file:

```bash
NAME="Zirconium"
VERSION="44 (Forty Four Prerelease)"
RELEASE_TYPE=development
ID=fedora
VERSION_ID=44
VERSION_CODENAME="Juno"
PRETTY_NAME="Zirconium"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:zirconium-dev:zirconium"
DEFAULT_HOSTNAME="zirconium"
HOME_URL="https://github.com/zirconium-dev/zirconium"
DOCUMENTATION_URL="https://github.com/zirconium-dev/zirconium"
SUPPORT_URL="https://github.com/zirconium-dev/zirconium/issues"
BUG_REPORT_URL="https://github.com/zirconium-dev/zirconium/issues"
SUPPORT_END=2027-05-19
BASE_OS_NAME="Fedora Linux 44"
```
Example of fastfetch with the new config (done with the os-release file shown above):
<img width="1171" height="624" alt="image" src="https://github.com/user-attachments/assets/c54592ec-e78e-4398-8fbe-d24fab5154f7" />

Example of fastfetch with the new config (done on Zirconium Hawaii):
<img width="1190" height="634" alt="image" src="https://github.com/user-attachments/assets/ae8f8ba8-d707-432a-8263-67e6fd54de86" />