### PR TITLE
Add gcr for gnome-keyring ssh support

### DIFF
--- a/build_files/01-theme-fetch.sh
+++ b/build_files/01-theme-fetch.sh
@@ -41,6 +41,7 @@ dnf -y install \
     foot \
     fpaste \
     fzf \
+    gcr \
     git-core \
     glycin-thumbnailer \
     gnome-disk-utility \

--- a/build_files/01-theme-post.sh
+++ b/build_files/01-theme-post.sh
@@ -25,6 +25,8 @@ systemctl preset --global foot-server.service
 systemctl preset --global foot-server.socket
 systemctl preset --global gnome-keyring-daemon.service
 systemctl preset --global gnome-keyring-daemon.socket
+systemctl preset --global gcr-ssh-agent.service
+systemctl preset --global gcr-ssh-agent.socket
 systemctl preset --global iio-niri.service
 systemctl preset --global udiskie.service
 

--- a/system_files/usr/lib/systemd/user-preset/01-zirconium.preset
+++ b/system_files/usr/lib/systemd/user-preset/01-zirconium.preset
@@ -6,5 +6,7 @@ enable foot-server.service
 enable foot-server.socket
 enable gnome-keyring-daemon.service
 enable gnome-keyring-daemon.socket
+enable gcr-ssh-agent.service
+enable gcr-ssh-agent.socket
 enable iio-niri.service
 enable udiskie.service


### PR DESCRIPTION
I've enabled it by default, I think this is a nice feature for everyone.

It works ootb with this setup.

Fixes #129