### PR TITLE
Add base os field to fastfetch

### DIFF
--- a/system_files/usr/share/zirconium/fastfetch.jsonc
+++ b/system_files/usr/share/zirconium/fastfetch.jsonc
@@ -23,6 +23,12 @@
             "format": "{pretty-name}"
         },
         {
+            "type": "command",
+            "key": " ",
+            "text": "echo Based on $(sed 's/release //;s/ ([^)]*)//' /etc/system-release)",
+            "shell": "/bin/bash"
+        },
+        {
             "type": "kernel",
             "key": " ",
             "format": "{1} {2}"


### PR DESCRIPTION
This adds a new line to fastfetch which pulls the Base OS Name from /etc/system-release. The result is this:

<img width="1137" height="722" alt="image" src="https://github.com/user-attachments/assets/d5696afe-ba85-4531-89c2-cfcc2e718cd0" />

This is made more for Zirconium Hawaii (since that OS is based off of Freedesktop SDK, and it'd be cool to showcase that somehow), but i made it also work for the Fedora based Zirconium. Theoretically, this would also work for a CentOS based Zirconium too, so that's cool.