### PR TITLE
fix: install and enable iwd for WiFi support

### DIFF
--- a/build_files/00-base-fetch.sh
+++ b/build_files/00-base-fetch.sh
@@ -50,6 +50,7 @@ dnf -y install \
   ibus \
   ifuse \
   intel-audio-firmware \
+  iwd \
   iwlegacy-firmware \
   iwlwifi-dvm-firmware \
   iwlwifi-mvm-firmware \

--- a/system_files/usr/lib/systemd/system-preset/01-zirconium.preset
+++ b/system_files/usr/lib/systemd/system-preset/01-zirconium.preset
@@ -4,6 +4,7 @@ enable brew-setup.service
 enable firewalld.service
 enable flatpak-preinstall.service
 enable greetd.service
+enable iwd.service
 enable systemd-resolved.service
 enable systemd-timesyncd.service
 enable tailscaled.service


### PR DESCRIPTION
Closes #147

## Problem

`/etc/NetworkManager/conf.d/iwd.conf` ships in the image (via the `dms-cli` package) and configures NetworkManager to use `iwd` as its WiFi backend:

```ini
[device]
wifi.backend=iwd
```

However, `iwd` was never installed. This causes NM to permanently mark the WiFi device as `unavailable` on boot, with all `WIFI-PROPERTIES` reporting `no` or `unknown` — making WiFi completely non-functional.

## Root cause trace

1. NM starts, reads `iwd.conf`, expects `iwd` on D-Bus
2. `iwd` is not installed → NM cannot initialize the WiFi device
3. Device transitions `unmanaged → unavailable` and stays there
4. `wpa_supplicant` is running but NM ignores it (wrong backend configured)

## Fix

- Install `iwd` in `00-base-fetch.sh`
- Enable `iwd.service` in the system preset

## Tested on

MediaTek MT7922 (`mt7921e` driver) — WiFi was fully non-functional before this fix and works correctly after.