### PR TITLE
Add /usr/share/cli-policy.json file to fix zjust update-greeter

### DIFF
--- a/system_files/usr/share/dms/cli-policy.json
+++ b/system_files/usr/share/dms/cli-policy.json
@@ -1,0 +1,8 @@
+{
+  "policy_version": 1,
+  "blocked_commands": [
+    "greeter install",
+    "greeter enable",
+    "setup"
+  ]
+}


### PR DESCRIPTION
A recent DMS commit (https://github.com/AvengeMedia/DankMaterialShell/commit/1eca9b4c2cc1972d01bdb332a3e2668337c88459) added a policy that disables a few commands. One of these commands is `greeter sync`, which is the command that is ran in `zjust update-greeter`. This PR adds a policy file that will re-enable that command specifically.
