### PR TITLE
chore(gitignore): remove accidental LGPL identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ _build_*
 output
 _build-*/**
 *.img
-# SPDX-License-Identifier: LGPL-2.1-or-later
 mkosi.local/
 mkosi.local.conf
 mkosi.output/


### PR DESCRIPTION
This was an accident, we want AGPL on the entire repo

