### PR TITLE
fix: updates-testing repo not being used with mkosi

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -8,6 +8,9 @@ ExtraTrees=
     assets/logos/logo-z.svg:/usr/share/zirconium/pixmaps/logo-z.svg
     assets/logos/watermark.png:/usr/share/plymouth/themes/spinner/watermark.png
 
+[Distribution]
+Repositories=updates-testing
+
 [Content]
 RemoveFiles=
     /usr/lib/systemd/system/flatpak-add-fedora-repos.service


### PR DESCRIPTION
Its enabled but idk why its not being used
