### PR TITLE
chore: only make rechunker workaround run on booted system

### DIFF
--- a/mkosi.profiles/bootc-ostree/mkosi.extra/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/mkosi.profiles/bootc-ostree/mkosi.extra/usr/lib/systemd/system/rechunker-group-fix.service
@@ -14,6 +14,7 @@
 # This got created on Tue, 16 Dec 2025 00:44:58 -0300
 [Unit]
 Description=Fix groups for Legacy rechunker
+ConditionPathExists=/run/ostree-booted
 Wants=local-fs.target
 After=local-fs.target
 Before=systemd-user-sessions.service


### PR DESCRIPTION
Shouldn't run on live ISOs and such, no idea how to handle the composefs native backend, whatever