### PR TITLE
chore: add dnf5-plugins

### DIFF
--- a/mkosi.profiles/fedora-bootc-ostree/mkosi.conf.d/goodies.conf
+++ b/mkosi.profiles/fedora-bootc-ostree/mkosi.conf.d/goodies.conf
@@ -6,6 +6,7 @@ Distribution=fedora
 WithRecommends=true
 Packages=
     dnf5
+    dnf5-plugins
     dracut-network
     dracut-squash
     efibootmgr


### PR DESCRIPTION
should probably be just included here for custom images and troubleshooting with usroverlays, even tho it is not needed for the build itself.