### PR TITLE
fix(rechunk): allow docker to pull this image

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ ostree-rechunk:
           -t \
           -v /var/lib/containers:/var/lib/containers \
           "quay.io/centos-bootc/centos-bootc:stream10" \
-          /usr/libexec/bootc-base-imagectl rechunk --max-layers 167 \
+          /usr/libexec/bootc-base-imagectl rechunk --max-layers 120 \
           "{{image}}" \
           "{{image}}" || exit 1
 


### PR DESCRIPTION
docker has a 128 layer cap