### PR TITLE
feat: use ntpd-rs because its awesome

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/01-zirconium.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/01-zirconium.preset
@@ -1,3 +1,4 @@
+disable systemd-timesyncd.service
 enable auditd.service
 enable bootc-fetch-apply-updates.timer
 enable brew-setup.service
@@ -5,7 +6,7 @@ enable firewalld.service
 enable flatpak-add-flathub-repos.service
 enable flatpak-preinstall.service
 enable greetd.service
+enable ntpd-rs.service
 enable systemd-resolved.service
-enable systemd-timesyncd.service
 enable tailscaled.service
 enable uupd.timer

--- a/mkosi.profiles/fedora-bootc-ostree/mkosi.conf
+++ b/mkosi.profiles/fedora-bootc-ostree/mkosi.conf
@@ -1,4 +1,5 @@
 # This profile attempts to replicate what quay.io/fedora/fedora-bootc:latest does.
+# This is also specific to zirconium. This might not have things you want.
 [Match]
 Profiles=fedora-bootc-ostree
 Distribution=fedora

--- a/mkosi.profiles/fedora-bootc-ostree/mkosi.conf.d/others.conf
+++ b/mkosi.profiles/fedora-bootc-ostree/mkosi.conf.d/others.conf
@@ -35,6 +35,7 @@ Packages=
     lvm2
     net-tools
     nftables
+    ntpd-rs
     nvme-cli
     passwd
     rpm-plugin-selinux


### PR DESCRIPTION
This fixes systemd-timesyncd always failing to work because of stuff like selinux