### PR TITLE
fix: base-desktop profile not being recognized

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -1,6 +1,6 @@
 [Config]
 MinimumVersion=26~devel
-Profiles=base,bootc-ostree,fedora-bootc-ostree
+Profiles=base-desktop,bootc-ostree,fedora-bootc-ostree
 
 [Distribution]
 Distribution=fedora

--- a/mkosi.profiles/base-desktop/mkosi.conf
+++ b/mkosi.profiles/base-desktop/mkosi.conf
@@ -1,6 +1,6 @@
 # Profile for wider hardware support
 # Based off of Silverblue/Kinoite images but without a desktop session
 [Match]
-Profiles=base
+Profiles=base-desktop
 Distribution=fedora
 


### PR DESCRIPTION
Apparently you need both the name of the thing and the folder to be equal to actually get the profile to apply.

1600 -> 1800 packages.
