### PR TITLE
fix: add openrgb udev rules

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -75,13 +75,14 @@ Packages=
     nautilus
     nautilus-python
     ncurses
+    openrgb-udev-rules
     openssh-askpass
     orca
     plasma-breeze
     playerctl
+    qt6ct
     qt6-qtimageformats
     qt6-qtmultimedia
-    qt6ct
     steam-devices
     tailscale
     tesseract


### PR DESCRIPTION
This is a fix someone noticed was missing.
