### PR TITLE
ci: fix non-base image builds

### DIFF
--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -145,6 +145,7 @@ jobs:
           CI_MKOSI_RELEASE: ${{ inputs.release }}
           IMAGE_FULL: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
         run: |
+          set -e
           RELEASE_ARGUMENTS=()
           if [ "$CI_MKOSI_RELEASE" != "" ] ; then
             RELEASE_ARGUMENTS+=("--release=$CI_MKOSI_RELEASE")
@@ -153,23 +154,19 @@ jobs:
 
       - name: Load image
         id: load
-        env:
-          IMAGE_FULL: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
         run: |
-          sudo "$(which just)" load
+          set -e
+          sudo env IMAGE_FULL="localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "$(which just)" load
 
       - name: Rechunk image
-        id: rechunk
-        env:
-          IMAGE_FULL: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
         run: |
-          sudo "$(which just)" ostree-rechunk
+          set -e
+          sudo env IMAGE_FULL="localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "$(which just)" ostree-rechunk
 
       - name: Lint image
-        env:
-          IMAGE_FULL: localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
         run: |
-          sudo "$(which just)" lint
+          set -e
+          sudo env IMAGE_FULL="localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "$(which just)" lint
 
       # https://github.com/actions/cache/issues/1533
       - name: Hack around permission issue caching


### PR DESCRIPTION
The images were being tagged with the base name so they were failing to push
