### PR TITLE
fix: re-add distrobox

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -42,6 +42,7 @@ Packages=
     default-fonts
     default-fonts-core-emoji
     distribution-gpg-keys
+    distrobox
     fastfetch
     fcitx5-chinese-addons
     fcitx5-mozc


### PR DESCRIPTION
[This](https://github.com/zirconium-dev/zirconium/commit/29ce36540540baae940c010b5febf531af9e4e17) is the offending commit that removed distrobox.

uupd, as taken from ublue-os/packages, has distrobox listed as a "Recommended" package. uupd, as taken from terra, does not have distrobox listed as a "Recommended" package. We do not explicitly add distrobox as a package.

Tulip Blossom is evil
