### PR TITLE
chore(pipewire): remove explicit raop install

### DIFF
--- a/mkosi.profiles/base-desktop/mkosi.conf.d/base-desktop.conf
+++ b/mkosi.profiles/base-desktop/mkosi.conf.d/base-desktop.conf
@@ -72,7 +72,6 @@ Packages=
     pam_yubico
     pcsc-lite
     pipewire
-    pipewire-config-raop
     pipewire-gstreamer
     pipewire-utils
     plymouth


### PR DESCRIPTION
This thing is awful and confusing

