### PR TITLE
fix(iio-niri): fix 2.0 update flags in service

### DIFF
--- a/mkosi.extra/usr/lib/systemd/user/iio-niri.service
+++ b/mkosi.extra/usr/lib/systemd/user/iio-niri.service
@@ -4,7 +4,7 @@ PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]
-ExecStart=iio-niri
+ExecStart=iio-niri listen
 Restart=on-failure
 RestartSec=1
 


### PR DESCRIPTION
We really should upstream this service..

Requires: https://github.com/terrapkg/packages/pull/11873

