### PR TITLE
chore: remove lchsh

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -12,6 +12,7 @@ ExtraTrees=
 WithRecommends=true
 RemoveFiles=
     /usr/bin/chsh
+    /usr/bin/lchsh
     /usr/lib/systemd/system/flatpak-add-fedora-repos.service
     /usr/share/applications/fcitx5-wayland-launcher.desktop
     /usr/share/applications/org.fcitx.Fcitx5*.desktop


### PR DESCRIPTION
libuser adds this binary alongside whatever puts /usr/bin/chsh in fedora

https://tim.siosm.fr/blog/2023/12/22/dont-change-defaut-login-shell/