### PR TITLE
chore: remove a workaround for bootc install

### DIFF
--- a/mkosi.conf.d/niri-git.conf
+++ b/mkosi.conf.d/niri-git.conf
@@ -8,7 +8,4 @@ SandboxTrees=repos/yalter-niri-git.repo:/etc/yum.repos.d/_copr:copr.fedorainfrac
 Repositories=copr:copr.fedorainfracloud.org:yalter:niri-git
 
 [Content]
-# https://github.com/niri-wm/niri/issues/2734
-RemoveFiles=
-    /usr/share/doc/niri
 Packages=niri

--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -16,7 +16,6 @@ RemoveFiles=
     /usr/share/applications/fcitx5-wayland-launcher.desktop
     /usr/share/applications/org.fcitx.Fcitx5*.desktop
     /usr/share/applications/foot-server.desktop
-    /usr/share/doc/just
 
 RemovePackages=
     alacritty


### PR DESCRIPTION
It previously made bootc install fail. https://github.com/ostreedev/ostree/pull/3559