### PR TITLE
feat(ci): use zstd for pushing

### DIFF
--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -206,7 +206,7 @@ jobs:
           # HACK: push a second time so layer annotations are present
           # TODO: remove me when https://github.com/containers/podman/issues/27796 fixed
           for i in $(seq "${MAX_RETRIES}"); do
-            sudo /home/linuxbrew/.linuxbrew/bin/podman push --digestfile=/tmp/digestfile "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${PLATFORM}" && break || sleep $((5 * i));
+            sudo /home/linuxbrew/.linuxbrew/bin/podman push --compression-format=zstd --digestfile=/tmp/digestfile "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${PLATFORM}" && break || sleep $((5 * i));
           done
           echo "remote_image_digest=$(< /tmp/digestfile)" | tee "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Not using zstd:chunked because nothing really supports it yet and can only break stuff if it doesn't fallback correctly, this is safe to do as even old versions of rpm-ostree and bootc work with this.

I did not test this for zirconium, no idea how much this supposedly saves. 