### PR TITLE
chore: rechunk to 127 layers and dedicate one for brew

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,7 +34,7 @@ ostree-rechunk:
           -t \
           -v /var/lib/containers:/var/lib/containers \
           "quay.io/centos-bootc/centos-bootc:stream10" \
-          /usr/libexec/bootc-base-imagectl rechunk --max-layers 120 \
+          /usr/libexec/bootc-base-imagectl rechunk --max-layers 127 \
           "{{image}}" \
           "{{image}}" || exit 1
 
@@ -62,7 +62,7 @@ rechunk:
     IMG="{{ image }}"
     # podman pull $IMG # image must be available locally
     export CHUNKAH_CONFIG_STR="$(sudo podman inspect "${IMG}")"
-    podman run --rm "--mount=type=image,src=${IMG},dest=/chunkah" -e CHUNKAH_CONFIG_STR quay.io/jlebon/chunkah build --label ostree.bootable=1 --compressed --max-layers 67 | \
+    podman run --rm "--mount=type=image,src=${IMG},dest=/chunkah" -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build --label ostree.bootable=1 --compressed --max-layers 128 | \
         podman load | \
         sort -n | \
         head -n1 | \

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -37,6 +37,8 @@ stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst
 stat /usr/lib/tmpfiles.d/homebrew.conf
 
+setfattr -n user.component -v "homebrew" /usr/share/homebrew.tar.zst
+
 HOME_URL="https://github.com/zirconium-dev/zirconium"
 echo "zirconium" | tee "/etc/hostname"
 # OS Release File (changed in order with upstream)


### PR DESCRIPTION
Bazzite and Aurora rechunks their images to 127 layers for more lean and small updates, an extra one is also added probably for ostree config or something similar, so in total it generates 128 layers which is maximum that overlay2 Docker driver supports (https://docs.docker.com/engine/storage/drivers/overlayfs-driver/#how-the-overlay2-driver-works)

Also dedicating one for Homebrew archive, no need to keep it in unpackaged layer