### PR TITLE
chore(fastfetch): remove appimages from package list

### DIFF
--- a/mkosi.extra/usr/bin/glorpfetch
+++ b/mkosi.extra/usr/bin/glorpfetch
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-fastfetch --logo /usr/share/zirconium/glorp.txt --config /usr/share/zirconium/fastfetch.jsonc "${@}"
+exec fastfetch --logo /usr/share/zirconium/glorp.txt --config /usr/share/zirconium/fastfetch.jsonc "${@}"

--- a/mkosi.extra/usr/share/zirconium/fastfetch.jsonc
+++ b/mkosi.extra/usr/share/zirconium/fastfetch.jsonc
@@ -97,7 +97,7 @@
         {
             "type": "packages",
             "key": " 󰏖",
-            "disabled": ["rpm"]
+            "disabled": ["rpm", "appimage"]
         },
         "break",
         {


### PR DESCRIPTION
This PR also fixes `glorpfetch` to show the user's shell correctly, instead of showing bash even when on a different shell.
