### PR TITLE
chore: fix flathub repos service

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system/flatpak-add-flathub-repos.service
+++ b/mkosi.extra/usr/lib/systemd/system/flatpak-add-flathub-repos.service
@@ -6,7 +6,7 @@ Before=flatpak-system-helper.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/flatpak remote-add --system --if-not-exists flathub /etc/flatpak/remotes.d/flathub.flatpakrepo
+ExecStart=/usr/bin/flatpak remote-add --system --if-not-exists flathub /usr/share/flatpak/remotes.d/flathub.flatpakrepo
 ExecStart=/usr/bin/flatpak remote-add --system --if-not-exists --disable --title "Fedora Flatpaks" fedora oci+https://registry.fedoraproject.org
 ExecStart=/usr/bin/flatpak remote-add --system --if-not-exists --disable --title "Fedora Flatpaks (testing)" fedora-testing oci+https://registry.fedoraproject.org#testing
 ExecStartPost=/usr/bin/touch /var/lib/flatpak/.flatpak-initialized


### PR DESCRIPTION
I just noticed that during boot, turns out we were failing to add the repo because I migrated the files to /usr/share!

