### PR TITLE
fix: disable openssh ootb

### DIFF
--- a/mkosi.profiles/base-desktop/mkosi.extra/usr/lib/systemd/system-preset/80-openssh.preset
+++ b/mkosi.profiles/base-desktop/mkosi.extra/usr/lib/systemd/system-preset/80-openssh.preset
@@ -1,0 +1,2 @@
+disable sshd.socket
+disable sshd.service


### PR DESCRIPTION
We don't explicitly disable openssh in a systemd preset anymore, which causes it to be enabled on brand new installations of Zirconium.

Ran in a fresh podman container of `ghcr.io/zirconium-dev/zirconium:latest`:

<img width="903" height="233" alt="image" src="https://github.com/user-attachments/assets/9d8eeee1-ecec-421a-a981-eec0d8144385" />
