### PR TITLE
fix(bootc-ostree): symlink `/media` to `/run/media`

### DIFF
--- a/mkosi.profiles/bootc-ostree/mkosi.postinst.chroot
+++ b/mkosi.profiles/bootc-ostree/mkosi.postinst.chroot
@@ -13,6 +13,7 @@ rm -rf /home /root /usr/local /srv /opt /mnt /usr/local /boot
 mkdir -p /boot /var /sysroot/ostree
 ln -s sysroot/ostree /ostree
 ln -sT var/home /home
+ln -sT run/media /media
 ln -sT var/mnt /mnt
 ln -sT var/opt /opt
 ln -sT var/roothome /root

--- a/mkosi.profiles/bootc-ostree/mkosi.postinst.chroot
+++ b/mkosi.profiles/bootc-ostree/mkosi.postinst.chroot
@@ -9,7 +9,7 @@ bootupctl backend generate-update-metadata
 # Necessary for general behavior expected by image-based systems
 sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd"
 
-rm -rf /home /root /usr/local /srv /opt /mnt /usr/local /boot
+rm -rf /home /root /usr/local /srv /opt /mnt /usr/local /boot /media
 mkdir -p /boot /var /sysroot/ostree
 ln -s sysroot/ostree /ostree
 ln -sT var/home /home


### PR DESCRIPTION
Thats the mutable path for it, forgot to do it!
