### PR TITLE
fix(ci): use ubuntu 24.04 images for build disk workflow

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         platform: ["amd64", "arm64"]
         flavor: ["", "-nvidia"]
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-26.04' || 'ubuntu-26.04-arm' }}
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
 
     steps:
       - name: Free disk space


### PR DESCRIPTION
It currently fails on getting Fedora mirrors of all things for whatever reason, better to revert back to Ubuntu 24.04 for now