### PR TITLE
chore: remove updates-testing in main images

### DIFF
--- a/mkosi.conf.d/non-rawhide.conf
+++ b/mkosi.conf.d/non-rawhide.conf
@@ -1,6 +1,0 @@
-[Match]
-Distribution=fedora
-Release=!rawhide
-
-[Distribution]
-Repositories=updates-testing


### PR DESCRIPTION
I don't see how to add a skip of certain configuration in mkosi docs, so removing it is