### PR TITLE
refactor: Use versioning in tags consistent with mkosi's internal $IMAGE_VERSION

### DIFF
--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -58,6 +58,8 @@ jobs:
   generate_matrix:
     runs-on: ubuntu-26.04
     outputs:
+      image_version: ${{ steps.getversion.outputs.image_version }}
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set matrix
@@ -104,6 +106,10 @@ jobs:
           sudo mv mkosi /usr/src/mkosi
           sudo ln -sf "/usr/src/mkosi/bin/mkosi" /usr/bin/mkosi
 
+      - name: Set mkosi.version
+        # We need to do this because mkosi.version is not persistent between builds on CI
+        run: skopeo list-tags docker://${IMAGE_REGISTRY}/${IMAGE_NAME} | jq --arg date "$(date -u +%Y%m%d)" -r '.Tags[] | select(startswith($date+"."))' | sort -n | tail -1 > mkosi.version
+
       - name: Render configuration (for debugging)
         run: mkosi cat-config --debug
 
@@ -120,6 +126,12 @@ jobs:
             RELEASE_ARGUMENTS+=("--release=$CI_MKOSI_RELEASE")
           fi
           sudo mkosi -B -ff --debug --profile=bootc-ostree,${CI_MKOSI_PROFILES} ${PROFILE_ARGUMENTS} ${RELEASE_ARGUMENTS}
+
+      - name: Get Version
+        id: getversion
+        run: |
+          set -e
+          echo "image_version=$(cat mkosi.version)" >> "$GITHUB_OUTPUT"
 
       - name: Load image
         id: load
@@ -249,11 +261,11 @@ jobs:
             type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}
             type=raw,value=${{ env.DEFAULT_TAG }}-${{ github.sha }}
             type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}-${{ github.sha }}
-            type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
-            type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}.{{date 'YYYYMMDD'}}
-            type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}-${{ github.sha }}
-            type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}.{{date 'YYYYMMDD'}}-${{ github.sha }}
-            type=raw,value={{ date 'YYYYMMDD'}},enable=${{ env.DEFAULT_TAG == 'latest' }}
+            type=raw,value=${{ env.DEFAULT_TAG }}.${{ needs.build_push.outputs.image_version }}
+            type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}.${{ needs.build_push.outputs.image_version }}
+            type=raw,value=${{ env.DEFAULT_TAG }}.${{ needs.build_push.outputs.image_version }}-${{ github.sha }}
+            type=raw,value=${{ steps.imagemetadata.outputs.distributionversion }}.${{ needs.build_push.outputs.image_version }}-${{ github.sha }}
+            type=raw,value=${{ needs.build_push.outputs.image_version }},enable=${{ env.DEFAULT_TAG == 'latest' }}
             type=ref,event=pr
             type=sha,enable=${{ github.event_name == 'pull_request' }}
           labels: |
@@ -272,7 +284,7 @@ jobs:
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/${{ github.sha }}
             org.opencontainers.image.vendor=${{ github.repository_owner }}
-            org.opencontainers.image.version=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
+            org.opencontainers.image.version=${{ env.DEFAULT_TAG }}.${{ needs.build_push.outputs.image_version }}
 
       - name: Login to GitHub Container Registry
         if: inputs.publish

--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -58,8 +58,6 @@ jobs:
   generate_matrix:
     runs-on: ubuntu-26.04
     outputs:
-      image_version: ${{ steps.getversion.outputs.image_version }}
-    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set matrix
@@ -85,6 +83,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-26.04' || 'ubuntu-26.04-arm' }}
+    outputs:
+      image_version: ${{ steps.getversion.outputs.image_version }}
     steps:
       - name: Free disk space
         uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2

--- a/mkosi.bump
+++ b/mkosi.bump
@@ -1,4 +1,26 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env python
+from datetime import datetime, timezone
 
-date -u +%Y%m%d%H%M%S
+DEFAULT_INDEX=0
+
+cur_date = datetime.now(timezone.utc).strftime("%Y%m%d")
+old_date = None
+old_index = 0
+
+# Try to find the old version. If the file is missing or fails to parse, don't do anything
+try:
+    old_version = open("mkosi.version", "r").read().split(".")
+    if len(old_version) == 2:
+        old_date = old_version[0]
+        old_index = int(old_version[1])
+
+except FileNotFoundError, ValueError:
+    pass
+
+# If the date timestamp (YYYYMMDD) of the last built version is the same as the one we want to build, increment the counter index. If not, reset to 0
+if old_date != cur_date:
+    print(f"{cur_date}.{DEFAULT_INDEX}")
+else:
+    new_index = old_index + 1
+    print(f"{cur_date}.{new_index}")
+

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -63,4 +63,5 @@ s|^DEFAULT_HOSTNAME=.*|DEFAULT_HOSTNAME="zirconium"|
 /^REDHAT_SUPPORT_PRODUCT_VERSION=/d
 EOF
 echo "VARIANT_ID=container" >> /usr/lib/os-release
+echo "IMAGE_VERSION=${IMAGE_VERSION}" >> /usr/lib/os-release
 ln -s fedora-release /usr/lib/system-release


### PR DESCRIPTION
Switch to an image naming scheme similar to Universal Blue, where images are named `YYYYMMDD.V` instead of simply `YYYYMMDD`. The `V` is a version number for disambiguation and it increments by 1 for every build on the same day.

`mkosi.bump` has been rewritten in Python to first check the existing `mkosi.version` and increment it if necessary according to this versioning scheme. Index starts at 0, so the first image built on any given day will be `YYYYMMDD.0`. This phases out the messy hack that was used before of using `YYYYMMDDHHMMSS` as the version `mkosi.bump` would return and then separately versioning the image itself.

Features:
- `/etc/os-release` now has the version of the currently booted image under `IMAGE_VERSION`
- `bootc status` will list the version associated with every deployment
- All of this versioning is consistent with the tags on Github, so users know exactly which image they are on
- Every build that succeeds, CI or local, will have a new version ID. This will be the case even when multiple images are built on the same day.

NOTE: This is a draft PR. I have tested that it builds and bumps correctly locally, but I have not been able to test the CI or a live system myself. It is worth testing this to make sure the change didn't break anything, however I have made very similar changes to Amethyris and Apollo and did most of my troubleshooting there.