### PR TITLE
Add xdg-desktop-portal-wlr to fix Screenshot portal on niri

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -101,6 +101,7 @@ Packages=
     wtype
     xdg-desktop-portal-gnome
     xdg-desktop-portal-gtk
+    xdg-desktop-portal-wlr
     xdg-terminal-exec
     xdg-user-dirs
     xorg-x11-server-Xwayland

--- a/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
@@ -13,3 +13,6 @@ L /etc/profile.d/zmotd.sh
 # Upstream to DMS
 d /etc/greetd/niri
 f /etc/greetd/niri/config.kdl
+
+d /etc/xdg-desktop-portal
+L /etc/xdg-desktop-portal/portals.conf

--- a/mkosi.extra/usr/share/factory/etc/xdg-desktop-portal/portals.conf
+++ b/mkosi.extra/usr/share/factory/etc/xdg-desktop-portal/portals.conf
@@ -1,0 +1,3 @@
+[preferred]
+default=gnome
+org.freedesktop.impl.portal.Screenshot=wlr


### PR DESCRIPTION
## Problem

Apps using the XDG screenshot portal (e.g. Gradia) fail silently on niri. The root cause is that `xdg-desktop-portal-gnome` implements its Screenshot portal by calling `org.gnome.Shell.Screenshot.InteractiveScreenshot` on D-Bus. niri exposes `org.gnome.Shell.Screenshot` for compatibility but does not implement `InteractiveScreenshot`, so the call fails with `Unknown method`.

Relevant log from `xdg-desktop-portal-gnome`:
```
InteractiveScreenshot failed: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Unknown method 'InteractiveScreenshot'
```

## Fix

- Add `xdg-desktop-portal-wlr` to the package list. It uses the `wlr-screencopy` Wayland protocol, which niri supports.
- Ship `/etc/xdg-desktop-portal/portals.conf` (via the existing factory file mechanism) that routes only the `Screenshot` interface to `wlr`, keeping the GNOME backend as default for everything else.

## Testing

Verified on a niri system running Zirconium: after installing `xdg-desktop-portal-wlr` and placing the `portals.conf`, Gradia's "take a snapshot" button works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)