### PR TITLE
fix: set DMS_PRIVESC to run0 instead of sudo

### DIFF
--- a/mkosi.extra/usr/share/factory/etc/profile.d/zirconium-dms-vars.sh
+++ b/mkosi.extra/usr/share/factory/etc/profile.d/zirconium-dms-vars.sh
@@ -1,1 +1,1 @@
-export DMS_PRIVESC=sudo
+export DMS_PRIVESC=run0


### PR DESCRIPTION
With this set to sudo, it breaks configuration options that require privilege escalation within the Lock Screen settings inside of DMS.

<img width="806" height="135" alt="image" src="https://github.com/user-attachments/assets/601784b4-4130-4a39-8517-4ffebb8154bc" />
