### PR TITLE
fix: workaround upstream issue where tools tree is missing passwd

### DIFF
--- a/mkosi.conf.d/theme.conf
+++ b/mkosi.conf.d/theme.conf
@@ -106,3 +106,8 @@ Packages=
     xorg-x11-server-Xwayland
     xwayland-satellite
     ykman
+
+# FIXME: Remove once https://github.com/systemd/mkosi/pull/4390 is merged
+[Build]
+ToolsTreePackages=
+    passwd


### PR DESCRIPTION
Remove when https://github.com/systemd/mkosi/pull/4390 is merged

