### PR TITLE
feat: Adding dankcalendar-git to zirconium

### DIFF
--- a/mkosi.conf.d/fedora/mkosi.conf.d/avengemedia-danklinux.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/avengemedia-danklinux.conf
@@ -10,4 +10,5 @@ Packages=
     dgop
     dsearch
     quickshell-git
+    dankcalendar-git
 


### PR DESCRIPTION
DMS 1.5 includes Dankcalendar integration.  This adds it in to zirconium.