### PR TITLE
fix: add libfido2 required by libssh

### DIFF
--- a/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
+++ b/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
@@ -40,6 +40,7 @@ Packages=
     libcamera-gstreamer
     libcamera-tools
     libcamera-v4l2
+    libfido2
     libimobiledevice
     libimobiledevice-utils
     libratbag-ratbagd


### PR DESCRIPTION
Dunno why it's not a dependency in libssh but I guess it's now required? Builds are failing because of it