### PR TITLE
fix(brew): remove stat tmpfiles conf

### DIFF
--- a/mkosi.profiles/brew/mkosi.postinst.chroot
+++ b/mkosi.profiles/brew/mkosi.postinst.chroot
@@ -6,6 +6,5 @@ install -Dpm0644 -t /usr/share/ "${SRCDIR}/cache/homebrew.tar.zst"
 
 stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst
-stat /usr/lib/tmpfiles.d/homebrew.conf
 
 setfattr -n user.component -v "homebrew" /usr/share/homebrew.tar.zst


### PR DESCRIPTION
This file doesn't exist in uBlue's Brew packaging, no wonder why builds are failing