### PR TITLE
chore: remove gvfs-archive

### DIFF
--- a/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
+++ b/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
@@ -23,7 +23,6 @@ Packages=
     fuse-common
     gstreamer1-plugin-dav1d
     gstreamer1-plugin-openh264
-    gvfs-archive
     gvfs-mtp
     gvfs-nfs
     gvfs-smb


### PR DESCRIPTION
This isn't supported in fedora anymore (probably unmaintained atp)
