### PR TITLE
fix(kmscon): disable kmscon on greetd TTY so that login doesn't break on rawhide

### DIFF
--- a/mkosi.conf.d/fedora-rawhide/mkosi.conf
+++ b/mkosi.conf.d/fedora-rawhide/mkosi.conf
@@ -1,0 +1,4 @@
+# Note: remove this once base zirconium is bumped to Fedora 45
+[Match]
+Distribution=fedora
+Release=rawhide

--- a/mkosi.conf.d/fedora-rawhide/mkosi.extra/usr/lib/systemd/system-preset/99-kmscon.preset
+++ b/mkosi.conf.d/fedora-rawhide/mkosi.extra/usr/lib/systemd/system-preset/99-kmscon.preset
@@ -1,0 +1,9 @@
+disable kmsconvt@tty1.service
+enable kmsconvt@tty2.service
+enable kmsconvt@tty3.service
+enable kmsconvt@tty4.service
+enable kmsconvt@tty5.service
+enable kmsconvt@tty6.service
+enable kmsconvt@tty7.service
+enable kmsconvt@tty8.service
+enable kmsconvt@tty9.service

--- a/mkosi.extra/usr/share/factory/etc/greetd/config.toml
+++ b/mkosi.extra/usr/share/factory/etc/greetd/config.toml
@@ -2,6 +2,7 @@
 service = "greetd-spawn"
 
 [terminal]
+# Note: KMSCON will break greetd wherever the VT is started
 vt = 1
 
 [default_session]

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -6,6 +6,9 @@ install -Dpm0644 -t /usr/share/flatpak/remotes.d/ "$SRCDIR/cache/flathub.flatpak
 
 niri --version | grep -i -E "niri [[:digit:]]*\.[[:digit:]]* (.*\.git\..*)"
 
+# We don't want to have the fedora default here. KMSCON should be disabled where greetd is started
+sed -i "/.*kmsconvt@\.service/d" /usr/lib/systemd/system-preset/90-default.preset
+
 install -d /usr/share/zirconium/
 install -Dpm0644 -t /usr/lib/pam.d/ /usr/share/quickshell/dms/assets/pam/* # Fixes long login times on fingerprint auth
 sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd


### PR DESCRIPTION
This also affects F45. Probably will be fixed by greetd someday
