### PR TITLE
feat(brew): move to brew-proxy by default

### DIFF
--- a/mkosi.extra/usr/lib/systemd/system-preset/01-zirconium.preset
+++ b/mkosi.extra/usr/lib/systemd/system-preset/01-zirconium.preset
@@ -3,7 +3,6 @@ disable bootc-fetch-apply-updates.timer
 disable sshd.socket
 disable sshd.service
 enable auditd.service
-enable brew-setup.service
 enable firewalld.service
 enable flatpak-add-flathub-repos.service
 enable flatpak-preinstall.service

--- a/mkosi.profiles/brew/mkosi.conf.d/fedora.conf
+++ b/mkosi.profiles/brew/mkosi.conf.d/fedora.conf
@@ -4,4 +4,5 @@ Distribution=fedora
 [Content]
 Packages=
     binutils
+    brew-proxy
     gcc

--- a/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew-proxy.preset
+++ b/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew-proxy.preset
@@ -1,0 +1,2 @@
+enable brew-proxy-daemon.service
+enable brew-proxy-setup.service

--- a/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
+++ b/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
@@ -1,0 +1,1 @@
+enable brew-setup.service

--- a/mkosi.profiles/brew/mkosi.postinst.chroot
+++ b/mkosi.profiles/brew/mkosi.postinst.chroot
@@ -4,6 +4,8 @@ set -xeuo pipefail
 
 install -Dpm0644 -t /usr/share/ "${SRCDIR}/cache/homebrew.tar.zst"
 
+# ublue-brew's brew-setup service specifically targets /var/home, which breaks on sysupdate because thats not in $PATH
+sed -i 's@/var@@' /usr/lib/systemd/system/brew-setup.service
 stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst
 


### PR DESCRIPTION
Makes it a lot easier to do sysupdate later, also brew-proxy is awesome and makes it so you can use brew with multiple users

`/var` is removed so that this doesn't break sysupdate