### PR TITLE
chore(greetd, kmscon): add override to greetd for kmscon instead of preset

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,10 +5,10 @@ default:
     #!/usr/bin/env bash
     set -xeuo pipefail
     just build
-    just load
-    just lint
-    just rechunk
-    env BUILD_BASE_DIR=/tmp just disk-image
+    sudo just load
+    sudo just lint
+    sudo just rechunk
+    sudo env BUILD_BASE_DIR=/tmp just disk-image
     vmbuddy -f /tmp/bootable.img
 
 build: build-ostree

--- a/mkosi.conf.d/fedora-rawhide/mkosi.conf
+++ b/mkosi.conf.d/fedora-rawhide/mkosi.conf
@@ -1,4 +1,0 @@
-# Note: remove this once base zirconium is bumped to Fedora 45
-[Match]
-Distribution=fedora
-Release=rawhide

--- a/mkosi.conf.d/fedora-rawhide/mkosi.extra/usr/lib/systemd/system-preset/99-kmscon.preset
+++ b/mkosi.conf.d/fedora-rawhide/mkosi.extra/usr/lib/systemd/system-preset/99-kmscon.preset
@@ -1,9 +1,0 @@
-disable kmsconvt@tty1.service
-enable kmsconvt@tty2.service
-enable kmsconvt@tty3.service
-enable kmsconvt@tty4.service
-enable kmsconvt@tty5.service
-enable kmsconvt@tty6.service
-enable kmsconvt@tty7.service
-enable kmsconvt@tty8.service
-enable kmsconvt@tty9.service

--- a/mkosi.extra/usr/lib/systemd/system/greetd.service.d/20-kmscon.conf
+++ b/mkosi.extra/usr/lib/systemd/system/greetd.service.d/20-kmscon.conf
@@ -1,0 +1,5 @@
+[Unit]
+# This needs to be on the same TTY that greetd is ran off of. Check greetd.conf
+Conflicts=kmsconvt@tty1.service
+After=kmsconvt@tty1.service
+

--- a/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
@@ -10,6 +10,7 @@ L /etc/profile.d/zirconium-font-settings.sh
 L /etc/profile.d/zirconium-qt-override.sh
 L /etc/profile.d/zirconium-dms-vars.sh
 L /etc/profile.d/zmotd.sh
+L /etc/kmscon/kmscon.conf
 
 # Upstream to DMS
 d /etc/greetd/niri

--- a/mkosi.extra/usr/share/factory/etc/kmscon/kmscon.conf
+++ b/mkosi.extra/usr/share/factory/etc/kmscon/kmscon.conf
@@ -1,0 +1,1 @@
+font-name=Maple Mono

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -6,9 +6,6 @@ install -Dpm0644 -t /usr/share/flatpak/remotes.d/ "$SRCDIR/cache/flathub.flatpak
 
 niri --version | grep -i -E "niri [[:digit:]]*\.[[:digit:]]* (.*\.git\..*)"
 
-# We don't want to have the fedora default here. KMSCON should be disabled where greetd is started
-sed -i "/.*kmsconvt@\.service/d" /usr/lib/systemd/system-preset/90-default.preset
-
 install -d /usr/share/zirconium/
 install -Dpm0644 -t /usr/lib/pam.d/ /usr/share/quickshell/dms/assets/pam/* # Fixes long login times on fingerprint auth
 sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd


### PR DESCRIPTION
This is what GNOME OS does.

