### PR TITLE
fix(brew-proxy): followup feedback from hec and luma

### DIFF
--- a/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew-proxy.preset
+++ b/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew-proxy.preset
@@ -1,2 +1,0 @@
-enable brew-proxy-daemon.service
-enable brew-proxy-setup.service

--- a/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
+++ b/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
@@ -1,1 +1,2 @@
+enable brew-proxy-setup.service
 enable brew-setup.service

--- a/mkosi.profiles/brew/mkosi.postinst.chroot
+++ b/mkosi.profiles/brew/mkosi.postinst.chroot
@@ -4,8 +4,6 @@ set -xeuo pipefail
 
 install -Dpm0644 -t /usr/share/ "${SRCDIR}/cache/homebrew.tar.zst"
 
-# ublue-brew's brew-setup service specifically targets /var/home, which breaks on sysupdate because thats not in $PATH
-sed -i 's@/var@@' /usr/lib/systemd/system/brew-setup.service
 stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst
 


### PR DESCRIPTION
Thank you two!

- `/var` is [fixed upstream](https://github.com/ublue-os/brew/commit/4576300de21e0ee3fc951895fe0e5edc04adf4cb)
- `brew-proxy-daemon` doesn't need to be `enabled`