### PR TITLE
fix(bootc): setUID/setfiles for SELinux not working

### DIFF
--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -117,7 +117,7 @@ jobs:
           if [ "$CI_MKOSI_RELEASE" != "" ] ; then
             RELEASE_ARGUMENTS+=("--release=$CI_MKOSI_RELEASE")
           fi
-          mkosi -B -ff --debug --profile=base,base-desktop,bootc-ostree,brew,zirconium-bootc-ostree,${CI_MKOSI_PROFILES} ${PROFILE_ARGUMENTS} ${RELEASE_ARGUMENTS}
+          sudo mkosi -B -ff --debug --profile=base,base-desktop,bootc-ostree,brew,zirconium-bootc-ostree,${CI_MKOSI_PROFILES} ${PROFILE_ARGUMENTS} ${RELEASE_ARGUMENTS}
 
       - name: Load image
         id: load


### PR DESCRIPTION
This happens because the runner doesn't have perms to do that, setfiles tries to run and cant set the files, newgidmap and newuidmap dont work, i'm surprised sudo works at all
