### PR TITLE
feat(ci): use --output oci for chunkah

### DIFF
--- a/.github/workflows/build-nvidia-bootc.yaml
+++ b/.github/workflows/build-nvidia-bootc.yaml
@@ -27,5 +27,4 @@ jobs:
       image-name: zirconium-nvidia
       platforms: amd64,arm64
       profiles: nvidia
-      rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/build-rawhide-bootc.yaml
+++ b/.github/workflows/build-rawhide-bootc.yaml
@@ -28,5 +28,4 @@ jobs:
       platforms: amd64,arm64
       default-tag: rawhide
       release: rawhide
-      rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/build-standard-bootc.yaml
+++ b/.github/workflows/build-standard-bootc.yaml
@@ -26,5 +26,4 @@ jobs:
     with:
       image-name: zirconium
       platforms: amd64,arm64
-      rechunk: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       publish: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -21,11 +21,6 @@ on:
         required: false
         type: string
         default: "amd64,arm64"
-      rechunk:
-        description: "Rechunk the build"
-        required: false
-        type: boolean
-        default: true
       publish:
         description: "Publish this image"
         required: false

--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -126,7 +126,6 @@ jobs:
           env IMAGE_FULL="localhost/${IMAGE_NAME}:${DEFAULT_TAG}" $(which just) load
 
       - name: Rechunk image
-        if: inputs.rechunk
         run: |
           set -e
           env IMAGE_FULL="localhost/${IMAGE_NAME}:${DEFAULT_TAG}" $(which just) rechunk

--- a/Justfile
+++ b/Justfile
@@ -70,12 +70,27 @@ disk-image $filesystem=filesystem:
 
 rechunk $image_name=image:
     #!/usr/bin/env bash
-    export CHUNKAH_CONFIG_STR="$(podman inspect "${image_name}")"
+    set -eoux pipefail
+
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
+    CHUNKAH_CONFIG_FILE="$(mktemp)"
+
+    trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
+    podman inspect "${image_name}" > "${CHUNKAH_CONFIG_FILE}"
+
     podman run --rm "--mount=type=image,src=${image_name},target=/chunkah" \
-        -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build \
+        -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
+        -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+        quay.io/coreos/chunkah:latest build \
+        --verbose \
+        --compressed \
         --prune /sysroot/ --label containers.bootc=1 \
-        --compressed --max-layers 128 --tag "${image_name}" \
-        | podman load
+        --max-layers 128 --tag "${image_name}" \
+        --config /chunkah-config.json \
+        --output oci:/run/out/chunked
+
+    CHUNKED_IMAGE="$(podman pull "oci:${CHUNKAH_OUTPUT_DIR}/chunked")"
+    podman tag "${CHUNKED_IMAGE}" "${image_name}"
 
 clean:
     mkosi clean


### PR DESCRIPTION
This is significantly faster than the podman load approach.

See: https://github.com/coreos/chunkah#output-options

Putting the compressed(!) oci-dir inside /tmp in GHA is fine as long as
we don't fill it up.

Not using compression and putting things outside of /tmp is not worth
it.

See: https://github.com/ublue-os/aurora/pull/2554