### PR TITLE
fix(sysupdate): add systemd-boot-unsigned package

### DIFF
--- a/mkosi.profiles/sysupdate/mkosi.conf.d/fedora/mkosi.conf
+++ b/mkosi.profiles/sysupdate/mkosi.conf.d/fedora/mkosi.conf
@@ -2,4 +2,6 @@
 Distribution=fedora
 
 [Content]
-Packages=systemd-container
+Packages=
+    systemd-container
+    systemd-boot-unsigned


### PR DESCRIPTION
DDI builds are failing because systemd-boot is missing. Testing this PR locally shows that they build after this. Yay.
