### PR TITLE
Small fixes for /etc in sysupdate

### DIFF
--- a/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/99-zirconium-factory.conf
@@ -8,7 +8,3 @@ L /etc/profile.d/zirconium-dms-vars.sh
 L /etc/profile.d/zmotd.sh
 L /etc/profile.d/zprompt.sh
 L /etc/kmscon/kmscon.conf
-
-# Upstream to DMS
-d /etc/greetd/niri
-f /etc/greetd/niri/config.kdl

--- a/mkosi.extra/usr/share/factory/etc/greetd/config.toml
+++ b/mkosi.extra/usr/share/factory/etc/greetd/config.toml
@@ -6,5 +6,5 @@ service = "greetd-spawn"
 vt = 1
 
 [default_session]
-command = "dms-greeter --command niri --cache-dir /var/cache/dms-greeter -C /etc/greetd/niri/config.kdl"
+command = "dms-greeter --command niri --cache-dir /var/cache/dms-greeter"
 user = "greeter"

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -70,3 +70,5 @@ L? /etc/manpath.config
 L? /etc/wpa_supplicant/wpa_supplicant.conf
 # Make sure flatpak's XDG_DATA_DIR integration works
 L? /etc/profile.d/flatpak.sh
+# This should probably be a default in Fedora
+L /etc/issue - - - - ../usr/lib/issue

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/tmpfiles.d/etc.conf
@@ -72,3 +72,6 @@ L? /etc/wpa_supplicant/wpa_supplicant.conf
 L? /etc/profile.d/flatpak.sh
 # This should probably be a default in Fedora
 L /etc/issue - - - - ../usr/lib/issue
+# So that subuids can be set at all
+f /etc/subuid
+f /etc/subgid


### PR DESCRIPTION
Note before reading this: I think that the way `/etc` in sysupdate Zirc images should be completely changed. I personally like the way that GnomeOS handles their `/etc`. They use a mutable confext, which allows for seamless updates to `/etc` between image upgrades without locking the ability to edit these files in `/etc` behind a symlink to a read-only `/usr/share/factory/etc` directory. Some of these files *should* be editable. Until/unless we change to something similar, I will make small fixes here and there to sysupdate's `/etc` as I see them during testing.

### The actual message for this PR:

Most of these changes are fairly self-explanatory. The change to `/usr/share/factory/etc/greetd/config.toml` is to get around an issue that *only* occurs on sysupdate images, seemingly because the `/etc/greetd/config.toml` file is already populated on bootc images before tmpfiles can get its hands on it.

When greetd launches, it shows niri's keybinds. We shouldn't populate this config ourselves by default, dms-greeter already has a default niri config that it falls back to.
<img width="2556" height="1332" alt="image" src="https://github.com/user-attachments/assets/b519fa54-a1de-4b4b-9374-cde278eb94b8" />
