### PR TITLE
fix(bootc): use unaffected bootc ver and handle it differently

### DIFF
--- a/mkosi.conf.d/rollback/mkosi.conf
+++ b/mkosi.conf.d/rollback/mkosi.conf
@@ -1,3 +1,0 @@
-[Match]
-Release=44
-Profiles=bootc-ostree

--- a/mkosi.conf.d/rollback/mkosi.postinst.chroot
+++ b/mkosi.conf.d/rollback/mkosi.postinst.chroot
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -xeuo pipefail
-
-dnf swap -y --disablerepo=* bootc "$SRCDIR/cache/bootc.rpm"

--- a/mkosi.conf.d/rollback/mkosi.prepare.chroot
+++ b/mkosi.conf.d/rollback/mkosi.prepare.chroot
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -xeuo pipefail
-
-mkdir -p "${SRCDIR}/cache"
-
-# Yay, bootc regression!
-curl -o "${SRCDIR}/cache/bootc.rpm" "https://kojipkgs.fedoraproject.org//packages/bootc/1.16.3/1.fc44/$(arch)/bootc-1.16.3-1.fc44.$(arch).rpm"

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-arm64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-arm64.conf
@@ -1,0 +1,9 @@
+# https://github.com/bootc-dev/bootc/issues/2339
+
+[Match]
+Release=44
+Architecture=arm64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/bootc/1.16.2/1.fc44/aarch64/bootc-1.16.2-1.fc44.aarch64.rpm

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-rawhide.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-rawhide.conf
@@ -1,0 +1,6 @@
+[Match]
+Release=rawhide
+
+[Content]
+Packages=
+    bootc

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-x64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-x64.conf
@@ -1,0 +1,9 @@
+# https://github.com/bootc-dev/bootc/issues/2339
+
+[Match]
+Release=44
+Architecture=x86-64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/bootc/1.16.2/1.fc44/x86_64/bootc-1.16.2-1.fc44.x86_64.rpm

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
@@ -1,6 +1,5 @@
 [Content]
 Packages=
-    bootc
     bootupd
     ostree
     rpm-ostree


### PR DESCRIPTION
Should resolve #354 while we're waiting for upstream fix. Also it has been redone to use mkosi config without touching cache directory