### PR TITLE
feat: set EPOCH for reproducibility in chunkah

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,6 +82,7 @@ rechunk $image_name=image:
     podman run --rm "--mount=type=image,src=${image_name},target=/chunkah" \
         -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
         -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+        -e SOURCE_DATE_EPOCH=0 \
         quay.io/coreos/chunkah:latest build \
         --verbose \
         --compressed \


### PR DESCRIPTION
This makes a crazy difference for unpackaged files.

Only drawback with this is that `podman images` now lists it as 56 years ago, but whatever. On my custom image this makes the update size of "useless rebuilds" with no relevant changes just the layer of the rpmdb.

I'm guessing here it'll still be the initramfs that is never reproducible currently due to timestamps in os-release.