### PR TITLE
fix: set org.opencontainers.image.created in chunkah

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -73,6 +73,11 @@ rechunk $image_name=image:
     #!/usr/bin/env bash
     set -eoux pipefail
 
+    # FIXME: Bandaid fix for
+    # https://github.com/zirconium-dev/zirconium/issues/363
+    # Do this properly in mkosi at some point
+    DATE="$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)"
+
     CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
     CHUNKAH_CONFIG_FILE="$(mktemp)"
 
@@ -86,7 +91,8 @@ rechunk $image_name=image:
         quay.io/coreos/chunkah:latest build \
         --verbose \
         --compressed \
-        --prune /sysroot/ --label containers.bootc=1 \
+        --prune /sysroot/ \
+        --label org.opencontainers.image.created="${DATE}" \
         --max-layers 128 --tag "${image_name}" \
         --config /chunkah-config.json \
         --output oci:/run/out/chunked


### PR DESCRIPTION
f7228843a9ed set the image creation date to epoch 0 and zirconium does not set any label metadata like org.opencontainers.image.version on it's images so tools like uupd and bootc fall back to the creation time instead.

I don't know why we are setting containers.bootc here in chunkah, that is already done by mkosi anyway.

Tested by rebasing to `ghcr.io/renner0e/zirconium:label-test` and running `sudo systemctl start --verbose uupd.service` and I don't get an annoying notification from uupd.

<img width="1249" height="356" alt="image" src="https://github.com/user-attachments/assets/6d7c9c5d-8d0b-4269-b995-b282b3a01ad4" />
