### PR TITLE
fix(jackrabbit): don't remove big picture session desktop file

### DIFF
--- a/mkosi.profiles/jackrabbit/mkosi.conf.d/fedora/mkosi.conf.d/terra.conf
+++ b/mkosi.profiles/jackrabbit/mkosi.conf.d/fedora/mkosi.conf.d/terra.conf
@@ -2,9 +2,6 @@
 Repositories=terra
 
 [Content]
-RemoveFiles=
-    /usr/share/wayland-sessions/gamescope-session-steam.desktop
-
 Packages=
     asusctl
     dkms-xonedo-nightly


### PR DESCRIPTION
I just realized that there's no need in removing this file while OGUI is not included here, it kinda makes it handheld unfriendly lol