### PR TITLE
chore: remove bootc 1.16.2 pin

### DIFF
--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-arm64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-arm64.conf
@@ -1,9 +1,0 @@
-# https://github.com/bootc-dev/bootc/issues/2339
-
-[Match]
-Release=44
-Architecture=arm64
-
-[Content]
-Packages=
-    https://kojipkgs.fedoraproject.org//packages/bootc/1.16.2/1.fc44/aarch64/bootc-1.16.2-1.fc44.aarch64.rpm

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-rawhide.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-rawhide.conf
@@ -1,6 +1,0 @@
-[Match]
-Release=rawhide
-
-[Content]
-Packages=
-    bootc

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-x64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc-x64.conf
@@ -1,9 +1,0 @@
-# https://github.com/bootc-dev/bootc/issues/2339
-
-[Match]
-Release=44
-Architecture=x86-64
-
-[Content]
-Packages=
-    https://kojipkgs.fedoraproject.org//packages/bootc/1.16.2/1.fc44/x86_64/bootc-1.16.2-1.fc44.x86_64.rpm

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
@@ -1,5 +1,6 @@
 [Content]
 Packages=
+    bootc
     bootupd
     ostree
     rpm-ostree


### PR DESCRIPTION
1.16.7 version is on Fedora repos now which includes a fix related to reading symlink files (policy.json to be exact)