### PR TITLE
chore: Set the tools tree release to 44

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -10,6 +10,7 @@ Hostname=zirconium
 
 [Build]
 ToolsTree=default
+ToolsTreeRelease=44
 History=yes
 CacheDirectory=mkosi.cache
 Incremental=yes


### PR DESCRIPTION
Working around this bug in Fedora Rawhide:

https://github.com/rpm-software-management/dnf5/issues/2861
