### PR TITLE
chore(liveiso-bootc-ostree): support setting a different image as target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ build-sysupdate:
     mkosi -B --debug-shell --profile=base,base-desktop,sysupdate,brew,base
 
 build-iso:
-    mkosi -B --debug --profile=iso
+    mkosi -B --debug-shell --profile=base,base-desktop,bootc-ostree,brew,zirconium-bootc-ostree,liveiso-bootc-ostree
 
 lint:
     podman run --rm -it --entrypoint=bootc {{ image }} container lint

--- a/mkosi.profiles/liveiso-bootc-ostree/mkosi.extra/usr/share/factory/etc/readymade.toml
+++ b/mkosi.profiles/liveiso-bootc-ostree/mkosi.extra/usr/share/factory/etc/readymade.toml
@@ -2,6 +2,7 @@
 allowed_installtypes = ["wholedisk"]
 copy_mode = "bootc"
 bootc_imgref = "oci:/usr/lib/zirconium/install/zirconium-oci"
+bootc_target_imgref = "ghcr.io/zirconium-dev/zirconium:latest"
 bootc_enforce_sigpolicy = true
 # bootc_args = ["--skip-fetch-check"]
 

--- a/mkosi.profiles/liveiso-bootc-ostree/mkosi.postinst.chroot
+++ b/mkosi.profiles/liveiso-bootc-ostree/mkosi.postinst.chroot
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-set -xeuo pipefail
+set -xeo pipefail
 
 mkdir -p /usr/lib/zirconium/install
 cp -r "${SRCDIR}/cache/zirconium-oci" /usr/lib/zirconium/install/
 systemd-firstboot --timezone UTC
 sed -i '/\/etc\/greetd/d' /usr/lib/tmpfiles.d/99-zirconium-factory.conf
 systemctl mask systemd-firstboot
+
+# Check for IMAGE_FULL env var
+if [[ -n "$IMAGE_FULL" ]]; then
+  echo "Setting image $IMAGE_FULL as target_imgref."
+else
+  IMAGE_FULL="ghcr.io/zirconium-dev/zirconium:latest"
+  echo "IMAGE_FULL not set. Setting the default image $IMAGE_FULL as target_imgref."
+fi
+
+sed --sandbox -i -e "s|bootc_target_imgref =.*|bootc_target_imgref = \"$IMAGE_FULL\"|g" /usr/share/factory/etc/readymade.toml
 
 KERNEL_PATH="$(find /usr/lib/modules -maxdepth 1 -type d | grep -v ".*.img" | tail -n 1)"
 dracut -v --force --add "dmsquash-live dmsquash-live-autooverlay" "${KERNEL_PATH}/initramfs.img" --kver "$(basename "${KERNEL_PATH}")"

--- a/mkosi.profiles/liveiso-bootc-ostree/mkosi.prepare.chroot
+++ b/mkosi.profiles/liveiso-bootc-ostree/mkosi.prepare.chroot
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
-set -xeuo pipefail
+set -xeo pipefail
 
 mkdir -p "${SRCDIR}/cache"
+
+# Check for IMAGE_FULL env var
+if [[ -n "$IMAGE_FULL" ]]; then
+  echo "Downloading image $IMAGE_FULL via skopeo."
+else
+  IMAGE_FULL="ghcr.io/zirconium-dev/zirconium:latest"
+  echo "IMAGE_FULL not set. Downloading the default image $IMAGE_FULL via skopeo."
+fi
+
 pushd "${SRCDIR}/cache"
-skopeo copy docker://ghcr.io/zirconium-dev/zirconium:latest "oci://${SRCDIR}/cache/zirconium-oci"
+skopeo copy docker://$IMAGE_FULL "oci://${SRCDIR}/cache/zirconium-oci"
 popd


### PR DESCRIPTION
After finding out about `--environment` flag in mkosi (in #376) it's possible to pick a different image to install on hard disk by setting `IMAGE_FULL` environment variable. It might also work for Hawaii but unsure about it right now (readymade doesn't have an option to set composefs backend in bootc install command though it can be easily patched afaik)