### PR TITLE
chore(brew): get all content of ublue brew oci image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "mkosi.extra/usr/share/zirconium/zdots"]
 	path = mkosi.extra/usr/share/zirconium/zdots
 	url = https://github.com/zirconium-dev/zdots.git
-[submodule "subprojects/ublue-brew"]
-	path = subprojects/ublue-brew
-	url = https://github.com/ublue-os/brew

--- a/mkosi.profiles/brew/mkosi.conf.d/subprojects.conf
+++ b/mkosi.profiles/brew/mkosi.conf.d/subprojects.conf
@@ -1,3 +1,0 @@
-[Content]
-ExtraTrees=
-    ../../subprojects/ublue-brew/system_files:/

--- a/mkosi.profiles/brew/mkosi.postinst.chroot
+++ b/mkosi.profiles/brew/mkosi.postinst.chroot
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-cp -r "${SRCDIR}/cache/ublue-brew/." /
+cp -a "${SRCDIR}/cache/ublue-brew/." /
 
 stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst

--- a/mkosi.profiles/brew/mkosi.postinst.chroot
+++ b/mkosi.profiles/brew/mkosi.postinst.chroot
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-install -Dpm0644 -t /usr/share/ "${SRCDIR}/cache/homebrew.tar.zst"
+cp -r "${SRCDIR}/cache/ublue-brew/." /
 
 stat /usr/lib/systemd/system/brew-setup.service
 stat /usr/share/homebrew.tar.zst

--- a/mkosi.profiles/brew/mkosi.prepare.chroot
+++ b/mkosi.profiles/brew/mkosi.prepare.chroot
@@ -9,8 +9,7 @@ if [ ! -e "${SRCDIR}/cache/crane" ] ; then
 	"${SRCDIR}/ghcurl" "${CRANE_URL}" -Lo /dev/stdout | tar -xvzf - -C "${SRCDIR}/cache" --owner=0 --group=0 --no-same-owner --no-same-permissions crane
 fi
 
-if [ ! -e "${SRCDIR}/cache/homebrew.tar.zst" ] ; then
-	"${SRCDIR}/cache/crane" export ghcr.io/ublue-os/brew:latest | tar -xvf - -C "${SRCDIR}/cache" system_files/usr/share/homebrew.tar.zst
-	mv "${SRCDIR}/cache/system_files/usr/share/homebrew.tar.zst" "${SRCDIR}/cache/homebrew.tar.zst"
-	rm -r "${SRCDIR}/cache/system_files"
+if [ ! -e "${SRCDIR}/cache/ublue-brew" ] ; then
+	"${SRCDIR}/cache/crane" export ghcr.io/ublue-os/brew:latest | tar -xvf - -C "${SRCDIR}/cache" system_files
+	mv "${SRCDIR}/cache/system_files" "${SRCDIR}/cache/ublue-brew"
 fi


### PR DESCRIPTION
This PR removes the need to keep this subproject in a first place, it really felt like getting the contents of OCI image with extra steps. Also it's copying files to rootfs instead of installing them since all the files have `644` permissions anyway