### PR TITLE
[sysupdate] Clean up some ParticleOS defaults

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,11 @@ build-ostree:
     mkosi -B --debug-shell --profile=base,base-desktop,bootc-ostree,brew,zirconium-bootc-ostree
 
 build-sysupdate:
-    mkosi -B --debug-shell --profile=base,base-desktop,sysupdate,brew,base
+    mkosi -B --debug-shell --profile=base,base-desktop,sysupdate,brew
+
+vm-sysupdate:
+    dd if=/dev/zero of=$(find "./mkosi.output" -maxdepth 1 -iname "{{ image_name }}*x86-64.raw") bs=1G count=0 seek=50
+    vmbuddy $(find "./mkosi.output" -maxdepth 1 -iname "{{ image_name }}*x86-64.raw")
 
 build-iso:
     mkosi -B --debug --profile=iso

--- a/mkosi.profiles/sysupdate/mkosi.extra/boot/loader/loader.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/boot/loader/loader.conf
@@ -1,1 +1,0 @@
-timeout 20

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/12-usr.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/12-usr.conf
@@ -2,6 +2,5 @@
 Type=usr
 Label=%M_%A
 SizeMinBytes=5G
-SizeMaxBytes=20G
-Weight=2000
+SizeMaxBytes=5G
 CopyBlocks=auto

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/22-usr.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/22-usr.conf
@@ -3,5 +3,4 @@ Type=usr
 Label=_empty
 NoAuto=1
 SizeMinBytes=5G
-SizeMaxBytes=20G
-Weight=2000
+SizeMaxBytes=5G

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/40-root.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/40-root.conf
@@ -6,5 +6,6 @@ Subvolumes=/var /home
 MakeDirectories=/var/log/journal
 # VMS DIE IF YOU DO THAT
 Encrypt=tpm2
+TPM2PCRs=7
 FactoryReset=yes
 Label=%M-root

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/40-root.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/40-root.conf
@@ -2,8 +2,7 @@
 Type=root
 Format=btrfs
 SizeMinBytes=10G
-Weight=20000
-Subvolumes=/var
+Subvolumes=/var /home
 MakeDirectories=/var/log/journal
 # VMS DIE IF YOU DO THAT
 Encrypt=tpm2

--- a/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/50-home.conf
+++ b/mkosi.profiles/sysupdate/mkosi.extra/usr/lib/repart.d/50-home.conf
@@ -1,7 +1,0 @@
-[Partition]
-Type=home
-Format=btrfs
-SizeMinBytes=10G
-Weight=40000
-FactoryReset=yes
-Label=%M-home

--- a/mkosi.profiles/sysupdate/mkosi.repart/12-usr.conf
+++ b/mkosi.profiles/sysupdate/mkosi.repart/12-usr.conf
@@ -8,3 +8,4 @@ VerityMatchKey=usr
 Minimize=yes
 Compression=zstd
 SplitName=%t.%U
+SizeMaxBytes=5G


### PR DESCRIPTION
- Fix the size of the /usr partition so it doesn't take up unnecessary space on larger disks
- Don't show the bootloader for 20 seconds at every boot by default
- Move /home to a subvolume of the root partition to help with space on constrained systems and avoid some issues with homed

Also, (as a consequence of the above) homed will now default to unencrypted btrfs subvolumes (on top of an encrypted root, so still encrypted just not per-user). I suggest adding a way to choose to use an encrypted loopback file instead in the final system, but for now this is a far less problematic configuration for homed for the average user.