### PR TITLE
chore(bootc-ostree): pin ostree to 2026.2

### DIFF
--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/bootc.conf
@@ -2,5 +2,4 @@
 Packages=
     bootc
     bootupd
-    ostree
     rpm-ostree

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-arm64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-arm64.conf
@@ -1,0 +1,11 @@
+# https://github.com/ostreedev/ostree/issues/3635
+# for now we're downgrading it while we're waiting for new builds in fedora repos
+
+[Match]
+Release=44
+Architecture=arm64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/ostree/2026.2/1.fc44/aarch64/ostree-2026.2-1.fc44.aarch64.rpm
+    https://kojipkgs.fedoraproject.org//packages/ostree/2026.2/1.fc44/aarch64/ostree-libs-2026.2-1.fc44.aarch64.rpm

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-rawhide.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-rawhide.conf
@@ -1,0 +1,6 @@
+[Match]
+Release=rawhide
+
+[Content]
+Packages=
+    ostree

--- a/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-x64.conf
+++ b/mkosi.profiles/bootc-ostree/mkosi.conf.d/fedora/mkosi.conf.d/ostree-x64.conf
@@ -1,0 +1,11 @@
+# https://github.com/ostreedev/ostree/issues/3635
+# for now we're downgrading it while we're waiting for new builds in fedora repos
+
+[Match]
+Release=44
+Architecture=x86-64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/ostree/2026.2/1.fc44/x86_64/ostree-2026.2-1.fc44.x86_64.rpm
+    https://kojipkgs.fedoraproject.org//packages/ostree/2026.2/1.fc44/x86_64/ostree-libs-2026.2-1.fc44.x86_64.rpm


### PR DESCRIPTION
Even though there's already an upstream release with a fix we still have to wait for Fedora to catch on :melting_face: 