### PR TITLE
include gvfs-gphoto2 dependency

### DIFF
--- a/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
+++ b/mkosi.profiles/base-desktop/mkosi.conf.d/fedora/mkosi.conf.d/base-desktop.conf
@@ -20,6 +20,7 @@ Packages=
     fuse-common
     gstreamer1-plugin-dav1d
     gstreamer1-plugin-openh264
+    gvfs-gphoto2
     gvfs-mtp
     gvfs-nfs
     gvfs-smb


### PR DESCRIPTION
Required to get PTP/MTP digital cameras to show up as filesystems in GNOME files