### PR TITLE
chore: install /usr/share/pixmaps/zirconium.svg

### DIFF
--- a/mkosi.conf.d/fedora/mkosi.conf.d/zirconium.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/zirconium.conf
@@ -1,6 +1,7 @@
 [Content]
 ExtraTrees=
     ../../assets/logos/logo-z.svg:/usr/share/zirconium/pixmaps/logo-z.svg
+    ../../assets/logos/logo-z.svg:/usr/share/pixmaps/zirconium.svg
     ../../assets/logos/watermark.png:/usr/share/plymouth/themes/spinner/watermark.png
     ../../assets/wallpapers:/usr/share/zirconium/skel/Pictures/Wallpapers
     ../../cosign.pub:/usr/share/pki/containers/zirconium.pub


### PR DESCRIPTION
We set LOGO=zirconium in os-release, so we should put the matching logo in the correct spot.

Can't get rid of /usr/share/zirconium/pixmaps/logo-z.svg because of tech debt reasons :/
