### PR TITLE
fix: pin xwayland-satellite to 0.8.1

### DIFF
--- a/mkosi.conf.d/fedora/mkosi.conf.d/zirconium-arm64.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/zirconium-arm64.conf
@@ -1,0 +1,8 @@
+# Temporary config to address https://github.com/Supreeeme/xwayland-satellite/issues/468
+
+[Match]
+Architecture=arm64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/xwayland-satellite/0.8.1/1.fc44/aarch64/xwayland-satellite-0.8.1-1.fc44.aarch64.rpm

--- a/mkosi.conf.d/fedora/mkosi.conf.d/zirconium-x64.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/zirconium-x64.conf
@@ -1,0 +1,8 @@
+# Temporary config to address https://github.com/Supreeeme/xwayland-satellite/issues/468
+
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+    https://kojipkgs.fedoraproject.org//packages/xwayland-satellite/0.8.1/1.fc44/x86_64/xwayland-satellite-0.8.1-1.fc44.x86_64.rpm

--- a/mkosi.conf.d/fedora/mkosi.conf.d/zirconium.conf
+++ b/mkosi.conf.d/fedora/mkosi.conf.d/zirconium.conf
@@ -91,7 +91,7 @@ Packages=
     xdg-terminal-exec
     xdg-user-dirs
     xorg-x11-server-Xwayland
-    xwayland-satellite
+    #xwayland-satellite
     ykman
 
 # FIXME: Remove once https://github.com/systemd/mkosi/pull/4390 is merged

--- a/mkosi.sandbox/etc/dnf/dnf.conf
+++ b/mkosi.sandbox/etc/dnf/dnf.conf
@@ -1,2 +1,3 @@
 [main]
+max_parallel_downloads=10
 exclude=abrt-cli alacritty appstream-data at bc chrony crontabs cyrus-sasl-plain deltarpm dos2unix dracut-config-rescue fuzzel grubby ibus-panel initial-setup* iptstate kernel-debug* mako mcelog mesa-va-drivers mtr noopenh264 PackageKit PackageKit-glib pinfo plocate psacct qemu-user-static realmd rsyslog* setroubleshoot setroubleshoot-plugins setroubleshoot-server sos sssd* swayidle swaylock systemd-networkd tcpdump traceroute waybar


### PR DESCRIPTION
Temporarily pinning it to older version due to a bug which causes Steam context menu to disappear immediately, even if "Enable context menu focus compatibility mode" was enabled in interface settings of the client.

Upstream issue: https://github.com/Supreeeme/xwayland-satellite/issues/468