### PR TITLE
chore: disable "greeter uninstall" and change update-greeter task

### DIFF
--- a/mkosi.extra/usr/share/dms/cli-policy.json
+++ b/mkosi.extra/usr/share/dms/cli-policy.json
@@ -3,6 +3,8 @@
   "blocked_commands": [
     "greeter install",
     "greeter enable",
+    "greeter uninstall",
     "setup"
-  ]
+  ],
+  "message": "This command is disabled on immutable/image-based systems. Use your distro-native workflow for system-level changes."
 }

--- a/mkosi.extra/usr/share/zirconium/just/00-start.just
+++ b/mkosi.extra/usr/share/zirconium/just/00-start.just
@@ -124,7 +124,7 @@ reset-niri:
     fi
 
 update-greeter:
-    DMS_PRIVESC=sudo dms greeter sync --auth
+    DMS_PRIVESC=sudo dms-greeter sync --auth
 
 # Turn automatic updates on or off
 toggle-updates ACTION="prompt":


### PR DESCRIPTION
Dank Greeter is now a separate package which deprecates `dms greeter` commands.