### PR TITLE
chore(brew): enable brew-proxy fix ownership service

### DIFF
--- a/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
+++ b/mkosi.profiles/brew/mkosi.extra/usr/lib/systemd/system-preset/10-brew.preset
@@ -1,2 +1,3 @@
-enable brew-proxy-setup.service
 enable brew-setup.service
+enable brew-proxy-setup.service
+enable brew-proxy-fix-ownership.service

--- a/mkosi.profiles/liveiso-bootc-ostree/mkosi.extra/usr/lib/systemd/system-preset/99-live.preset
+++ b/mkosi.profiles/liveiso-bootc-ostree/mkosi.extra/usr/lib/systemd/system-preset/99-live.preset
@@ -1,5 +1,3 @@
-disable brew-setup.service
-disable brew-update.service
 disable flatpak-preinstall.service
 disable greetd.service
 disable systemd-firstboot.service


### PR DESCRIPTION
Enabling a new service introduced in 0.3.6 release that should fix UID/GID drift for some users

https://codeberg.org/HastD/brew-proxy/releases/tag/v0.3.6